### PR TITLE
Add user registration endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ go run cmd/server/main.go
 1. [x] Project scaffolding (go mod, folder structure, main entrypoint)
 2. [x] Database connection (PostgreSQL, connection pooling, health check)
 3. [x] Database migrations (users, tracks, videos tables)
-4. [ ] User registration endpoint (`POST /auth/register`)
+4. [x] User registration endpoint (`POST /auth/register`)
 5. [ ] User login endpoint (`POST /auth/login`, JWT generation)
 6. [ ] JWT middleware (token validation, user context)
 7. [ ] Token refresh endpoint (`POST /auth/refresh`)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/wpinrui/dovora2/backend/internal/api"
 	"github.com/wpinrui/dovora2/backend/internal/db"
 )
 
@@ -41,7 +42,10 @@ func main() {
 	}
 	log.Println("Migrations complete")
 
+	authHandler := api.NewAuthHandler(database)
+
 	http.HandleFunc("/health", healthHandler(database))
+	http.HandleFunc("/auth/register", authHandler.Register)
 
 	server := &http.Server{
 		Addr:         ":" + port,

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,12 +2,15 @@ module github.com/wpinrui/dovora2/backend
 
 go 1.25.5
 
-require github.com/jackc/pgx/v5 v5.8.0
+require (
+	github.com/jackc/pgx/v5 v5.8.0
+	golang.org/x/crypto v0.46.0
+)
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/text v0.32.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -16,10 +16,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
-golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
+golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
+golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"net/mail"
+	"unicode"
+
+	"github.com/wpinrui/dovora2/backend/internal/auth"
+	"github.com/wpinrui/dovora2/backend/internal/db"
+)
+
+type AuthHandler struct {
+	db *db.DB
+}
+
+func NewAuthHandler(database *db.DB) *AuthHandler {
+	return &AuthHandler{db: database}
+}
+
+type registerRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type registerResponse struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := validateEmail(req.Email); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := validatePassword(req.Password); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	passwordHash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		log.Printf("Failed to hash password: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	user, err := h.db.CreateUser(r.Context(), req.Email, passwordHash)
+	if err != nil {
+		if errors.Is(err, db.ErrUserExists) {
+			writeError(w, http.StatusConflict, "email already registered")
+			return
+		}
+		log.Printf("Failed to create user: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(registerResponse{
+		ID:    user.ID,
+		Email: user.Email,
+	})
+}
+
+func validateEmail(email string) error {
+	if email == "" {
+		return errors.New("email is required")
+	}
+	if _, err := mail.ParseAddress(email); err != nil {
+		return errors.New("invalid email format")
+	}
+	return nil
+}
+
+func validatePassword(password string) error {
+	if password == "" {
+		return errors.New("password is required")
+	}
+	if len(password) < 8 {
+		return errors.New("password must be at least 8 characters")
+	}
+	if len(password) > 72 {
+		return errors.New("password must be at most 72 characters")
+	}
+
+	var hasUpper, hasLower, hasDigit bool
+	for _, r := range password {
+		switch {
+		case unicode.IsUpper(r):
+			hasUpper = true
+		case unicode.IsLower(r):
+			hasLower = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		}
+	}
+
+	if !hasUpper {
+		return errors.New("password must contain at least one uppercase letter")
+	}
+	if !hasLower {
+		return errors.New("password must contain at least one lowercase letter")
+	}
+	if !hasDigit {
+		return errors.New("password must contain at least one digit")
+	}
+
+	return nil
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(errorResponse{Error: message})
+}

--- a/backend/internal/auth/password.go
+++ b/backend/internal/auth/password.go
@@ -1,0 +1,22 @@
+package auth
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const bcryptCost = 12
+
+func HashPassword(password string) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
+	if err != nil {
+		return "", fmt.Errorf("hash password: %w", err)
+	}
+	return string(bytes), nil
+}
+
+func CheckPassword(password, hash string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	return err == nil
+}

--- a/backend/internal/db/user.go
+++ b/backend/internal/db/user.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+var ErrUserExists = errors.New("user with this email already exists")
+
+type User struct {
+	ID           string
+	Email        string
+	PasswordHash string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+func (db *DB) CreateUser(ctx context.Context, email, passwordHash string) (*User, error) {
+	var user User
+	err := db.Pool.QueryRow(ctx, `
+		INSERT INTO users (email, password_hash)
+		VALUES ($1, $2)
+		RETURNING id, email, password_hash, created_at, updated_at
+	`, email, passwordHash).Scan(&user.ID, &user.Email, &user.PasswordHash, &user.CreatedAt, &user.UpdatedAt)
+
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, ErrUserExists
+		}
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+
+	return &user, nil
+}
+
+func (db *DB) GetUserByEmail(ctx context.Context, email string) (*User, error) {
+	var user User
+	err := db.Pool.QueryRow(ctx, `
+		SELECT id, email, password_hash, created_at, updated_at
+		FROM users WHERE email = $1
+	`, email).Scan(&user.ID, &user.Email, &user.PasswordHash, &user.CreatedAt, &user.UpdatedAt)
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get user by email: %w", err)
+	}
+
+	return &user, nil
+}


### PR DESCRIPTION
Closes #4

## Summary
- Add POST /auth/register endpoint with email/password validation
- Implement bcrypt password hashing (cost 12)
- Add user repository with CreateUser and GetUserByEmail methods
- Handle duplicate email registration (409 Conflict)

## Test plan
- [ ] POST /auth/register with valid email/password returns 201 and user data
- [ ] POST /auth/register with duplicate email returns 409 Conflict
- [ ] POST /auth/register with invalid email returns 400 Bad Request
- [ ] POST /auth/register with weak password returns 400 Bad Request