### PR TITLE
Add JWT middleware for token validation and user context

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ go run cmd/server/main.go
 3. [x] Database migrations (users, tracks, videos tables)
 4. [x] User registration endpoint (`POST /auth/register`)
 5. [x] User login endpoint (`POST /auth/login`, JWT generation)
-6. [ ] JWT middleware (token validation, user context)
+6. [x] JWT middleware (token validation, user context)
 7. [ ] Token refresh endpoint (`POST /auth/refresh`)
 8. [ ] Invite system (generate codes, validate on register)
 9. [ ] Search endpoint (`GET /search`, Invidious API proxy)

--- a/backend/internal/api/middleware.go
+++ b/backend/internal/api/middleware.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/wpinrui/dovora2/backend/internal/auth"
+)
+
+type contextKey string
+
+const UserIDKey contextKey = "userID"
+
+type Middleware struct {
+	jwtSecret string
+}
+
+func NewMiddleware(jwtSecret string) *Middleware {
+	return &Middleware{jwtSecret: jwtSecret}
+}
+
+func (m *Middleware) RequireAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			writeError(w, http.StatusUnauthorized, "missing authorization header")
+			return
+		}
+
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+			writeError(w, http.StatusUnauthorized, "invalid authorization header format")
+			return
+		}
+
+		tokenString := parts[1]
+		claims, err := auth.ValidateToken(tokenString, m.jwtSecret, auth.TokenTypeAccess)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "invalid or expired token")
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), UserIDKey, claims.UserID)
+		next(w, r.WithContext(ctx))
+	}
+}
+
+func GetUserID(ctx context.Context) (string, bool) {
+	userID, ok := ctx.Value(UserIDKey).(string)
+	return userID, ok
+}


### PR DESCRIPTION
## Summary
- Add `ValidateToken` function to auth package for parsing and validating JWT tokens
- Create middleware that extracts Bearer token from Authorization header
- Inject user ID into request context for protected endpoints
- Add helper function `GetUserID(ctx)` to retrieve user ID from context

## Usage
```go
middleware := api.NewMiddleware(jwtSecret)
http.HandleFunc("/protected", middleware.RequireAuth(protectedHandler))
```

## Test plan
- [ ] Test middleware rejects requests without Authorization header
- [ ] Test middleware rejects requests with invalid token format
- [ ] Test middleware rejects expired tokens
- [ ] Test middleware rejects refresh tokens (only accepts access tokens)
- [ ] Test middleware passes valid requests with user ID in context

Closes #6