### PR TITLE
Add token refresh endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ go run cmd/server/main.go
 4. [x] User registration endpoint (`POST /auth/register`)
 5. [x] User login endpoint (`POST /auth/login`, JWT generation)
 6. [x] JWT middleware (token validation, user context)
-7. [ ] Token refresh endpoint (`POST /auth/refresh`)
+7. [x] Token refresh endpoint (`POST /auth/refresh`)
 8. [ ] Invite system (generate codes, validate on register)
 9. [ ] Search endpoint (`GET /search`, Invidious API proxy)
 10. [ ] yt-dlp integration (download audio/video, extract metadata)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -52,6 +52,7 @@ func main() {
 	http.HandleFunc("/health", healthHandler(database))
 	http.HandleFunc("/auth/register", authHandler.Register)
 	http.HandleFunc("/auth/login", authHandler.Login)
+	http.HandleFunc("/auth/refresh", authHandler.Refresh)
 
 	server := &http.Server{
 		Addr:         ":" + port,


### PR DESCRIPTION
Closes #7

## Summary
- Add `POST /auth/refresh` endpoint to renew JWT tokens
- Accepts refresh token in request body, returns new access + refresh token pair
- Validates token type to ensure only refresh tokens can be used

## Test plan
- [ ] Login to get tokens
- [ ] Call `/auth/refresh` with valid refresh token → returns new token pair
- [ ] Call `/auth/refresh` with access token → returns 401 (wrong token type)
- [ ] Call `/auth/refresh` with expired refresh token → returns 401
- [ ] Call `/auth/refresh` with invalid token → returns 401