### PR TITLE
Fix: Add .gitattributes for LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize line endings for Go files
+*.go text eol=lf


### PR DESCRIPTION
Closes #56

## Summary
- Adds `.gitattributes` to enforce LF line endings for `*.go` files
- Prevents future CRLF issues when committing from Windows

## Test plan
- [x] Verified existing Go files already have LF endings
- [ ] Future Go file edits should normalize to LF on commit