### PR TITLE
Add music library endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ go run cmd/server/main.go
 10. [x] yt-dlp integration (download audio/video, extract metadata)
 11. [x] Download endpoint (`POST /download`)
 12. [x] File serving endpoint (`GET /files/{id}`)
-13. [ ] Music library endpoints (`GET /library/music`, `DELETE /library/{id}`)
+13. [x] Music library endpoints (`GET /library/music`, `DELETE /library/{id}`)
 14. [ ] Video library endpoints (`GET /library/videos`)
 15. [ ] Track metadata update endpoint (rename title/artist)
 16. [ ] Lyrics endpoint (`GET /lyrics`, Genius API integration)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -72,6 +72,7 @@ func main() {
 	searchHandler := api.NewSearchHandler(invidiousClient)
 	downloadHandler := api.NewDownloadHandler(database, downloader)
 	fileHandler := api.NewFileHandler(database)
+	libraryHandler := api.NewLibraryHandler(database)
 	middleware := api.NewMiddleware(jwtSecret)
 
 	http.HandleFunc("/health", healthHandler(database))
@@ -83,6 +84,8 @@ func main() {
 	http.HandleFunc("/search", middleware.RequireAuth(searchHandler.Search))
 	http.HandleFunc("/download", middleware.RequireAuth(downloadHandler.Download))
 	http.HandleFunc("/files/", middleware.RequireAuth(fileHandler.ServeFile))
+	http.HandleFunc("/library/music", middleware.RequireAuth(libraryHandler.GetMusic))
+	http.HandleFunc("/library/", middleware.RequireAuth(libraryHandler.DeleteItem))
 
 	server := &http.Server{
 		Addr:         ":" + port,

--- a/backend/internal/api/library.go
+++ b/backend/internal/api/library.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/wpinrui/dovora2/backend/internal/db"
+)
+
+type LibraryHandler struct {
+	db *db.DB
+}
+
+func NewLibraryHandler(database *db.DB) *LibraryHandler {
+	return &LibraryHandler{db: database}
+}
+
+type trackResponse struct {
+	ID              string `json:"id"`
+	YoutubeID       string `json:"youtube_id"`
+	Title           string `json:"title"`
+	Artist          string `json:"artist"`
+	DurationSeconds int    `json:"duration_seconds"`
+	ThumbnailURL    string `json:"thumbnail_url"`
+	FileSizeBytes   int64  `json:"file_size_bytes"`
+	CreatedAt       string `json:"created_at"`
+}
+
+type libraryResponse struct {
+	Tracks []trackResponse `json:"tracks"`
+}
+
+func (h *LibraryHandler) GetMusic(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	userID, ok := GetUserID(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "user not found in context")
+		return
+	}
+
+	tracks, err := h.db.GetTracksByUserID(r.Context(), userID)
+	if err != nil {
+		log.Printf("Failed to get tracks for user %s: %v", userID, err)
+		writeError(w, http.StatusInternalServerError, "failed to get library")
+		return
+	}
+
+	response := libraryResponse{
+		Tracks: make([]trackResponse, 0, len(tracks)),
+	}
+
+	for _, track := range tracks {
+		response.Tracks = append(response.Tracks, trackResponse{
+			ID:              track.ID,
+			YoutubeID:       track.YoutubeID,
+			Title:           track.Title,
+			Artist:          track.Artist,
+			DurationSeconds: track.DurationSeconds,
+			ThumbnailURL:    track.ThumbnailURL,
+			FileSizeBytes:   track.FileSizeBytes,
+			CreatedAt:       track.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *LibraryHandler) DeleteItem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	userID, ok := GetUserID(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "user not found in context")
+		return
+	}
+
+	// Extract ID from URL path: /library/{id}
+	id := strings.TrimPrefix(r.URL.Path, "/library/")
+	if id == "" || id == r.URL.Path {
+		writeError(w, http.StatusBadRequest, "id is required")
+		return
+	}
+
+	// Try to delete as track first
+	filePath, err := h.db.DeleteTrack(r.Context(), id, userID)
+	if err == nil {
+		// Successfully deleted track, now delete file from disk
+		if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+			log.Printf("Failed to delete file %s: %v", filePath, err)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// If not found as track, check if it's a "not found" error
+	if !errors.Is(err, pgx.ErrNoRows) {
+		log.Printf("Failed to delete track: %v", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	// Track not found - item doesn't exist for this user
+	writeError(w, http.StatusNotFound, "item not found")
+}


### PR DESCRIPTION
Closes #12

## Summary
- Add `GET /library/music` endpoint to list user's music tracks
- Add `DELETE /library/{id}` endpoint to remove tracks from library (also deletes file from disk)
- Add `GetTracksByUserID` and `DeleteTrack` database methods

## Test plan
- [ ] GET /library/music returns user's tracks ordered by most recent
- [ ] DELETE /library/{id} removes track from database and file from disk
- [ ] Endpoints require authentication
- [ ] Users can only access/delete their own tracks