### PR TITLE
Add video library endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ go run cmd/server/main.go
 11. [x] Download endpoint (`POST /download`)
 12. [x] File serving endpoint (`GET /files/{id}`)
 13. [x] Music library endpoints (`GET /library/music`, `DELETE /library/{id}`)
-14. [ ] Video library endpoints (`GET /library/videos`)
+14. [x] Video library endpoints (`GET /library/videos`)
 15. [ ] Track metadata update endpoint (rename title/artist)
 16. [ ] Lyrics endpoint (`GET /lyrics`, Genius API integration)
 17. [ ] Playlist CRUD endpoints

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -85,6 +85,7 @@ func main() {
 	http.HandleFunc("/download", middleware.RequireAuth(downloadHandler.Download))
 	http.HandleFunc("/files/", middleware.RequireAuth(fileHandler.ServeFile))
 	http.HandleFunc("/library/music", middleware.RequireAuth(libraryHandler.GetMusic))
+	http.HandleFunc("/library/videos", middleware.RequireAuth(libraryHandler.GetVideos))
 	http.HandleFunc("/library/", middleware.RequireAuth(libraryHandler.DeleteItem))
 
 	server := &http.Server{


### PR DESCRIPTION
Closes #13

## Summary
- Add `GET /library/videos` endpoint to list user's video library
- Add `GetVideosByUserID` and `DeleteVideo` database methods
- Update `DELETE /library/{id}` to handle both tracks and videos

## Test plan
- [ ] Call `GET /library/videos` with valid auth token
- [ ] Verify response contains video objects with correct fields
- [ ] Test `DELETE /library/{id}` with a video ID