### PR TITLE
Add track metadata update endpoint (PATCH /tracks/{id})

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ go run cmd/server/main.go
 12. [x] File serving endpoint (`GET /files/{id}`)
 13. [x] Music library endpoints (`GET /library/music`, `DELETE /library/{id}`)
 14. [x] Video library endpoints (`GET /library/videos`)
-15. [ ] Track metadata update endpoint (rename title/artist)
+15. [x] Track metadata update endpoint (rename title/artist)
 16. [ ] Lyrics endpoint (`GET /lyrics`, Genius API integration)
 17. [ ] Playlist CRUD endpoints
 18. [ ] Dockerfile + docker-compose setup

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -87,6 +87,7 @@ func main() {
 	http.HandleFunc("/library/music", middleware.RequireAuth(libraryHandler.GetMusic))
 	http.HandleFunc("/library/videos", middleware.RequireAuth(libraryHandler.GetVideos))
 	http.HandleFunc("/library/", middleware.RequireAuth(libraryHandler.DeleteItem))
+	http.HandleFunc("/tracks/", middleware.RequireAuth(libraryHandler.UpdateTrack))
 
 	server := &http.Server{
 		Addr:         ":" + port,

--- a/backend/internal/db/media.go
+++ b/backend/internal/db/media.go
@@ -211,6 +211,37 @@ func (db *DB) GetTracksByUserID(ctx context.Context, userID string) ([]Track, er
 	return tracks, nil
 }
 
+// UpdateTrack updates the title and artist of a track for a specific user
+func (db *DB) UpdateTrack(ctx context.Context, trackID, userID, title, artist string) (*Track, error) {
+	query := `
+		UPDATE tracks
+		SET title = $3, artist = $4, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2
+		RETURNING id, user_id, youtube_id, title, artist, duration_seconds, thumbnail_url, file_path, file_size_bytes, created_at, updated_at
+	`
+
+	track := &Track{}
+	err := db.Pool.QueryRow(ctx, query, trackID, userID, title, artist).Scan(
+		&track.ID,
+		&track.UserID,
+		&track.YoutubeID,
+		&track.Title,
+		&track.Artist,
+		&track.DurationSeconds,
+		&track.ThumbnailURL,
+		&track.FilePath,
+		&track.FileSizeBytes,
+		&track.CreatedAt,
+		&track.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return track, nil
+}
+
 // DeleteTrack deletes a track by ID for a specific user and returns the file path
 func (db *DB) DeleteTrack(ctx context.Context, trackID, userID string) (string, error) {
 	query := `


### PR DESCRIPTION
## Summary
- Add `PATCH /tracks/{id}` endpoint to update track title and artist
- Add `UpdateTrack` database function in `db/media.go`
- Add `UpdateTrack` handler in `api/library.go`
- Supports partial updates (can update just title or just artist)

Closes #14