### PR TITLE
Add TokenStorage with encrypted SharedPreferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ go run cmd/server/main.go
 
 21. [x] Remove Firebase dependencies
 22. [x] API client setup (Retrofit, OkHttp with auth interceptor)
-23. [ ] Token storage (encrypted SharedPreferences)
+23. [x] Token storage (encrypted SharedPreferences)
 24. [ ] Login screen
 25. [ ] Register screen (with invite code)
 26. [ ] Auth state management (logged in/out, token refresh)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,7 +132,10 @@ dependencies {
     
     // Coroutines
     implementation(libs.kotlinx.coroutines.android)
-    
+
+    // Security (Encrypted SharedPreferences)
+    implementation(libs.androidx.security.crypto)
+
     // Image Loading
     implementation(libs.coil.compose)
 

--- a/app/src/main/java/com/wpinrui/dovora/data/api/TokenProvider.kt
+++ b/app/src/main/java/com/wpinrui/dovora/data/api/TokenProvider.kt
@@ -2,7 +2,7 @@ package com.wpinrui.dovora.data.api
 
 /**
  * Interface for providing and managing authentication tokens.
- * Implementation will use encrypted SharedPreferences (issue #23).
+ * Implementation uses encrypted SharedPreferences (see TokenStorage).
  */
 interface TokenProvider {
     /**

--- a/app/src/main/java/com/wpinrui/dovora/data/api/TokenStorage.kt
+++ b/app/src/main/java/com/wpinrui/dovora/data/api/TokenStorage.kt
@@ -1,0 +1,51 @@
+package com.wpinrui.dovora.data.api
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+
+/**
+ * Secure token storage using EncryptedSharedPreferences.
+ * Tokens are encrypted at rest using Android Keystore.
+ */
+class TokenStorage(context: Context) : TokenProvider {
+
+    private val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+    private val prefs: SharedPreferences = EncryptedSharedPreferences.create(
+        PREFS_NAME,
+        masterKeyAlias,
+        context,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    override fun getAccessToken(): String? {
+        return prefs.getString(KEY_ACCESS_TOKEN, null)
+    }
+
+    override fun getRefreshToken(): String? {
+        return prefs.getString(KEY_REFRESH_TOKEN, null)
+    }
+
+    override fun saveTokens(accessToken: String, refreshToken: String) {
+        prefs.edit()
+            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putString(KEY_REFRESH_TOKEN, refreshToken)
+            .apply()
+    }
+
+    override fun clearTokens() {
+        prefs.edit()
+            .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_REFRESH_TOKEN)
+            .apply()
+    }
+
+    companion object {
+        private const val PREFS_NAME = "dovora_secure_prefs"
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ coil = "2.7.0"
 media3 = "1.4.1"
 androidxMedia = "1.7.0"
 composePager = "0.32.0"
+securityCrypto = "1.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -49,6 +50,7 @@ media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "medi
 androidx-media = { group = "androidx.media", name = "media", version.ref = "androidxMedia" }
 compose-foundation-pager = { group = "com.google.accompanist", name = "accompanist-pager", version.ref = "composePager" }
 compose-foundation-pager-indicators = { group = "com.google.accompanist", name = "accompanist-pager-indicators", version.ref = "composePager" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Closes #22

## Summary
- Add AndroidX Security Crypto dependency for EncryptedSharedPreferences
- Create `TokenStorage` class implementing `TokenProvider` interface
- Tokens encrypted at rest using Android Keystore (AES256-GCM)
- Update TokenProvider docstring to reference implementation

## Test plan
- [ ] Build compiles successfully
- [ ] TokenStorage can save and retrieve tokens
- [ ] Tokens persist across app restarts
- [ ] clearTokens() removes all auth data