### PR TITLE
Add login screen with Go backend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ go run cmd/server/main.go
 21. [x] Remove Firebase dependencies
 22. [x] API client setup (Retrofit, OkHttp with auth interceptor)
 23. [x] Token storage (encrypted SharedPreferences)
-24. [ ] Login screen
+24. [x] Login screen
 25. [ ] Register screen (with invite code)
 26. [ ] Auth state management (logged in/out, token refresh)
 

--- a/app/src/main/java/com/wpinrui/dovora/ui/auth/AuthDialog.kt
+++ b/app/src/main/java/com/wpinrui/dovora/ui/auth/AuthDialog.kt
@@ -1,51 +1,75 @@
 package com.wpinrui.dovora.ui.auth
 
-import android.app.Activity
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import com.wpinrui.dovora.R
 
 @Composable
 fun SignInDialog(
     onDismiss: () -> Unit,
-    onSignInClick: () -> Unit,
+    onLogin: () -> Unit,
+    email: String,
+    onEmailChange: (String) -> Unit,
+    password: String,
+    onPasswordChange: (String) -> Unit,
     isSigningIn: Boolean,
     errorMessage: String?
 ) {
+    val focusManager = LocalFocusManager.current
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    val textFieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = Color.White,
+        unfocusedTextColor = Color.White,
+        focusedBorderColor = Color(0xFF6200EE),
+        unfocusedBorderColor = Color.White.copy(alpha = 0.5f),
+        focusedLabelColor = Color(0xFF6200EE),
+        unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+        cursorColor = Color.White
+    )
+
     AlertDialog(
         onDismissRequest = { if (!isSigningIn) onDismiss() },
         title = {
@@ -59,7 +83,7 @@ fun SignInDialog(
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 Text(
                     text = "Sign in to sync your library across devices",
@@ -67,7 +91,7 @@ fun SignInDialog(
                     fontSize = 14.sp,
                     textAlign = TextAlign.Center
                 )
-                
+
                 if (errorMessage != null) {
                     Text(
                         text = errorMessage,
@@ -76,53 +100,79 @@ fun SignInDialog(
                         textAlign = TextAlign.Center
                     )
                 }
-                
-                Spacer(modifier = Modifier.height(8.dp))
-                
-                // Google Sign-In Button
-                OutlinedButton(
-                    onClick = onSignInClick,
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = onEmailChange,
+                    label = { Text("Email") },
+                    singleLine = true,
                     enabled = !isSigningIn,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp),
-                    shape = RoundedCornerShape(24.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        containerColor = Color.White,
-                        contentColor = Color.Black
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Email,
+                        imeAction = ImeAction.Next
                     ),
-                    border = BorderStroke(1.dp, Color.LightGray)
-                ) {
-                    if (isSigningIn) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(24.dp),
-                            color = Color.Gray,
-                            strokeWidth = 2.dp
-                        )
-                    } else {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center
-                        ) {
-                            // Google logo placeholder (use Icon since we don't have the actual logo)
-                            Text(
-                                text = "G",
-                                fontSize = 18.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = Color(0xFF4285F4)
-                            )
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Text(
-                                text = "Continue with Google",
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Medium
+                    keyboardActions = KeyboardActions(
+                        onNext = { focusManager.moveFocus(FocusDirection.Down) }
+                    ),
+                    colors = textFieldColors,
+                    shape = RoundedCornerShape(12.dp)
+                )
+
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = onPasswordChange,
+                    label = { Text("Password") },
+                    singleLine = true,
+                    enabled = !isSigningIn,
+                    modifier = Modifier.fillMaxWidth(),
+                    visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            focusManager.clearFocus()
+                            onLogin()
+                        }
+                    ),
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription = if (passwordVisible) "Hide password" else "Show password",
+                                tint = Color.White.copy(alpha = 0.7f)
                             )
                         }
-                    }
+                    },
+                    colors = textFieldColors,
+                    shape = RoundedCornerShape(12.dp)
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onLogin,
+                enabled = !isSigningIn && email.isNotBlank() && password.isNotBlank(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF6200EE)
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                if (isSigningIn) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        color = Color.White,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text("Sign In")
                 }
             }
         },
-        confirmButton = {},
         dismissButton = {
             TextButton(
                 onClick = onDismiss,


### PR DESCRIPTION
Closes #23

## Summary
- Updated `AuthViewModel` to handle login via Go backend API (`POST /auth/login`)
- Updated `SignInDialog` with email/password fields instead of Google Sign-In
- Tokens are saved to encrypted storage on successful login
- Error states handled gracefully (invalid credentials, network errors)
- Removed Firebase/Google Sign-In launcher code

## Test plan
- [ ] Open the app and tap the account icon
- [ ] Tap "Sign In" to open the login dialog
- [ ] Verify email and password fields are shown
- [ ] Test login with invalid credentials - should show error
- [ ] Test login with valid credentials - should save tokens and close dialog