### PR TITLE
Add search screen with backend proxy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ go run cmd/server/main.go
 
 ### Android Phase 2: Music
 
-27. [ ] Search screen (Invidious integration)
+27. [x] Search screen (Invidious integration)
 28. [ ] Download flow (request to backend, progress tracking)
 29. [ ] Music library screen (list tracks from backend)
 30. [ ] Track detail/edit screen (rename title/artist)

--- a/app/src/main/java/com/wpinrui/dovora/data/repository/SearchRepository.kt
+++ b/app/src/main/java/com/wpinrui/dovora/data/repository/SearchRepository.kt
@@ -1,148 +1,119 @@
 package com.wpinrui.dovora.data.repository
 
+import android.content.Context
 import android.util.Log
-import com.wpinrui.dovora.data.api.InvidiousApiService
+import com.wpinrui.dovora.data.api.AuthRepository
+import com.wpinrui.dovora.data.api.DovoraApiService
 import com.wpinrui.dovora.data.api.MetadataService
-import com.wpinrui.dovora.data.api.RetrofitProvider
-import com.wpinrui.dovora.data.api.model.InvidiousSearchResponse
 import com.wpinrui.dovora.data.model.SearchResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.util.Locale
+import com.wpinrui.dovora.data.api.model.SearchResult as BackendSearchResult
 
-class SearchRepository(
-    private val apiService: InvidiousApiService = RetrofitProvider.createApiService()
+/**
+ * Repository for searching YouTube videos via the Dovora backend.
+ * Uses the backend's /search endpoint which proxies to Invidious,
+ * providing auth tracking and rate limiting.
+ */
+class SearchRepository private constructor(
+    private val context: Context
 ) {
-    
+    companion object {
+        private const val TAG = "SearchRepository"
+
+        @Volatile
+        private var instance: SearchRepository? = null
+
+        fun getInstance(context: Context): SearchRepository {
+            return instance ?: synchronized(this) {
+                instance ?: SearchRepository(context.applicationContext).also {
+                    instance = it
+                }
+            }
+        }
+    }
+
+    private val authRepository: AuthRepository
+        get() = AuthRepository.getInstance(context)
+
+    private val api: DovoraApiService
+        get() = authRepository.getAuthenticatedApi()
+
     suspend fun search(query: String): Flow<List<SearchResult>> = flow {
         if (query.isBlank()) {
             emit(emptyList())
             return@flow
         }
-        
-        // Try the primary instance first
-        var lastException: Exception? = null
-        var success = false
-        
-        for (instanceUrl in RetrofitProvider.getInvidiousInstances()) {
-            try {
-                val service = RetrofitProvider.createApiService(instanceUrl)
-                val response = service.search(query)
-                // Filter to only video type results (should be all since we request type="video", but be safe)
-                val videoResults = response.filter { it.type == "video" }
-                val results = videoResults.map { it.toSearchResult() }
-                
-                // Fetch metadata for each result's YouTube URL
-                // Since we're in a flow builder (suspend context), we can call suspend functions directly
+
+        try {
+            Log.d(TAG, "Searching for: $query")
+            val response = api.search(query)
+
+            if (response.isSuccessful) {
+                val searchResponse = response.body()
+                val backendResults = searchResponse?.results ?: emptyList()
+                Log.d(TAG, "Got ${backendResults.size} results from backend")
+
+                // Map backend results to app model
+                val results = backendResults.map { it.toSearchResult() }
+
+                // Fetch metadata for each result (for AI prefill)
                 val resultsWithMetadata = mutableListOf<SearchResult>()
                 for (result in results) {
                     val youtubeUrl = "https://www.youtube.com/watch?v=${result.id}"
-                    Log.d("SearchRepository", "Fetching metadata for: $youtubeUrl")
+                    Log.d(TAG, "Fetching metadata for: $youtubeUrl")
                     val metadata = fetchMetadataForUrl(youtubeUrl)
-                    Log.d("SearchRepository", "Got metadata for ${result.id}: title=${metadata?.songTitle}, artist=${metadata?.artist}")
+                    Log.d(TAG, "Got metadata for ${result.id}: title=${metadata?.songTitle}, artist=${metadata?.artist}")
                     resultsWithMetadata.add(result.copy(parsedMetadata = metadata))
                 }
-                Log.d("SearchRepository", "Emitting ${resultsWithMetadata.size} results with metadata")
-                emit(resultsWithMetadata)
-                success = true
-                break
-            } catch (e: Exception) {
-                lastException = e
-                // Log but continue to next instance
-                Log.e("SearchRepository", "Search failed for instance: ${e.message}", e)
-            }
-        }
 
-        // If all instances failed, fallback to mock results
-        if (!success) {
-            Log.e("SearchRepository", "All instances failed, using mock results", lastException)
-            emit(generateMockResults(query))
+                Log.d(TAG, "Emitting ${resultsWithMetadata.size} results with metadata")
+                emit(resultsWithMetadata)
+            } else {
+                Log.e(TAG, "Search failed: ${response.code()} - ${response.errorBody()?.string()}")
+                emit(emptyList())
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Search error: ${e.message}", e)
+            emit(emptyList())
         }
     }
-    
-    private fun InvidiousSearchResponse.toSearchResult(): SearchResult {
-        // Try to get the best thumbnail from Invidious, but prefer direct YouTube URLs
-        val invidiousThumbnail = videoThumbnails
-            ?.sortedByDescending { thumbnail ->
-                // Score based on quality name and resolution
-                when {
-                    thumbnail.quality.contains("maxres", ignoreCase = true) -> 1000
-                    thumbnail.quality.contains("sd", ignoreCase = true) -> 900
-                    thumbnail.quality == "high" -> 800
-                    thumbnail.width >= 640 && thumbnail.height >= 480 -> 700
-                    thumbnail.quality == "medium" -> 500
-                    thumbnail.quality == "default" -> 400
-                    else -> thumbnail.width * thumbnail.height // Fallback to resolution
-                }
-            }
-            ?.firstOrNull()
-            ?.url
-        
-        // Construct direct YouTube thumbnail URL for best quality
-        // YouTube has these resolutions: maxresdefault (1280x720), sddefault (640x480), hqdefault (480x360)
-        val directThumbnailUrl = "https://i.ytimg.com/vi/$videoId/maxresdefault.jpg"
-        
+
+    private fun BackendSearchResult.toSearchResult(): SearchResult {
+        // Use provided thumbnail URL or construct direct YouTube URL
+        val thumbnail = thumbnailUrl ?: "https://i.ytimg.com/vi/$videoId/maxresdefault.jpg"
+
         return SearchResult(
             id = videoId,
             title = title,
-            channel = author,
-            duration = formatDuration(lengthSeconds),
-            thumbnailUrl = directThumbnailUrl // Use direct URL for maximum quality
+            channel = author ?: "Unknown",
+            duration = formatDuration(duration ?: 0),
+            thumbnailUrl = thumbnail
         )
     }
-    
+
     private fun formatDuration(seconds: Int): String {
         val hours = seconds / 3600
         val minutes = (seconds % 3600) / 60
         val secs = seconds % 60
-        
+
         return when {
             hours > 0 -> String.format(Locale.ROOT, "%d:%02d:%02d", hours, minutes, secs)
             else -> String.format(Locale.ROOT, "%d:%02d", minutes, secs)
         }
     }
-    
+
     private suspend fun fetchMetadataForUrl(
         youtubeUrl: String
     ): com.wpinrui.dovora.data.api.ParsedMetadata? {
         val metadataService = MetadataService.getInstance()
         val result = metadataService.parseMetadata(youtubeUrl)
         result.onSuccess { metadata ->
-            Log.d("SearchRepository", "Fetched metadata for $youtubeUrl: title=${metadata.songTitle}, artist=${metadata.artist}")
+            Log.d(TAG, "Fetched metadata for $youtubeUrl: title=${metadata.songTitle}, artist=${metadata.artist}")
         }.onFailure { error ->
-            Log.e("SearchRepository", "Failed to fetch metadata for $youtubeUrl: ${error.message}")
+            Log.e(TAG, "Failed to fetch metadata for $youtubeUrl: ${error.message}")
         }
         return result.getOrNull()
     }
-    
-    private fun generateMockResults(query: String): List<SearchResult> {
-        // Fallback mock results if API fails
-        return listOf(
-            SearchResult(
-                id = "1",
-                title = "$query - Official Audio",
-                channel = "Artist Channel",
-                duration = "3:45",
-                thumbnailUrl = null,
-                parsedMetadata = null
-            ),
-            SearchResult(
-                id = "2",
-                title = "$query - Live Performance",
-                channel = "Live Music",
-                duration = "4:12",
-                thumbnailUrl = null,
-                parsedMetadata = null
-            ),
-            SearchResult(
-                id = "3",
-                title = "$query - Remix",
-                channel = "Remix Channel",
-                duration = "3:28",
-                thumbnailUrl = null,
-                parsedMetadata = null
-            )
-        )
-    }
 }
-

--- a/app/src/main/java/com/wpinrui/dovora/ui/MainScreen.kt
+++ b/app/src/main/java/com/wpinrui/dovora/ui/MainScreen.kt
@@ -146,17 +146,20 @@ fun MainScreen() {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
+    val context = LocalContext.current
     val playbackViewModel: MusicPlaybackViewModel = viewModel()
     val appViewModel: AppViewModel = viewModel()
     // Create SearchViewModel at activity level so it persists across navigation and app lifecycle
-    val searchViewModel: com.wpinrui.dovora.ui.search.SearchViewModel = viewModel(key = "search_viewmodel")
+    val searchViewModel: com.wpinrui.dovora.ui.search.SearchViewModel = viewModel(
+        key = "search_viewmodel",
+        factory = com.wpinrui.dovora.ui.search.SearchViewModel.Factory(context)
+    )
     val playbackUiState by playbackViewModel.uiState.collectAsState()
     val playerPage by playbackViewModel.playerPage.collectAsState()
     val dominantColor by playbackViewModel.dominantColor.collectAsState()
     val appMode by appViewModel.appMode.collectAsState()
     val videoLibrary by appViewModel.videoLibrary.collectAsState()
     val currentVideo by appViewModel.currentVideo.collectAsState()
-    val context = LocalContext.current
     
     // Auth ViewModel for UI (settings, account, etc.)
     val authRepository = remember { AuthRepository.getInstance(context) }

--- a/app/src/main/java/com/wpinrui/dovora/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wpinrui/dovora/ui/search/SearchViewModel.kt
@@ -1,6 +1,8 @@
 package com.wpinrui.dovora.ui.search
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.wpinrui.dovora.data.model.SearchResult
 import com.wpinrui.dovora.data.repository.SearchRepository
@@ -10,31 +12,31 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class SearchViewModel(
-    private val searchRepository: SearchRepository = SearchRepository()
+    private val searchRepository: SearchRepository
 ) : ViewModel() {
-    
+
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
-    
+
     private val _searchResults = MutableStateFlow<List<SearchResult>>(emptyList())
     val searchResults: StateFlow<List<SearchResult>> = _searchResults.asStateFlow()
-    
+
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-    
+
     private val _selectedResult = MutableStateFlow<SearchResult?>(null)
     val selectedResult: StateFlow<SearchResult?> = _selectedResult.asStateFlow()
 
     private val _hasPerformedSearch = MutableStateFlow(false)
     val hasPerformedSearch: StateFlow<Boolean> = _hasPerformedSearch.asStateFlow()
-    
+
     fun updateSearchQuery(query: String) {
         _searchQuery.value = query
         if (query.isBlank()) {
             _hasPerformedSearch.value = false
         }
     }
-    
+
     fun setInitialQuery(query: String) {
         if (query.isNotBlank()) {
             // Always clear previous state and set new query when navigating with a search param
@@ -44,13 +46,13 @@ class SearchViewModel(
             performSearch()
         }
     }
-    
+
     fun clearSearch() {
         _searchQuery.value = ""
         _searchResults.value = emptyList()
         _hasPerformedSearch.value = false
     }
-    
+
     fun performSearch() {
         val query = _searchQuery.value.trim()
         viewModelScope.launch {
@@ -59,7 +61,7 @@ class SearchViewModel(
                 _isLoading.value = false
                 return@launch
             }
-            
+
             _isLoading.value = true
             _hasPerformedSearch.value = true
             searchRepository.search(query).collect { results ->
@@ -68,12 +70,22 @@ class SearchViewModel(
             }
         }
     }
-    
+
     fun onResultClick(result: SearchResult) {
         _selectedResult.value = result
     }
-    
+
     fun dismissDownloadDialog() {
         _selectedResult.value = null
+    }
+
+    class Factory(private val context: Context) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(SearchViewModel::class.java)) {
+                return SearchViewModel(SearchRepository.getInstance(context)) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
     }
 }


### PR DESCRIPTION
Closes #26

## Summary
- Updated SearchRepository to use the Go backend's /search endpoint instead of direct Invidious API calls
- Backend proxy provides auth tracking and rate limiting
- Added ViewModelFactory pattern for SearchViewModel to support Context injection

## Test plan
- [ ] Login to the app
- [ ] Navigate to Search tab
- [ ] Enter a search query and press Search
- [ ] Verify results appear with thumbnails, titles, and durations
- [ ] Tap a result to trigger download flow